### PR TITLE
fix: where plugin stops working when adding a new minion to favourites

### DIFF
--- a/MinionRoulette/MinionRoulette.cs
+++ b/MinionRoulette/MinionRoulette.cs
@@ -67,10 +67,12 @@ public class Plugin : IDalamudPlugin
             case CmdMrToggle when Service.Configuration.PluginEnabled:
                 Service.Chat.Print("MinionRoulette Disabled");
                 Service.Configuration.PluginEnabled = false;
+                Service.Configuration.Save();
                 break;
             case CmdMrToggle:
                 Service.Chat.Print("MinionRoulette Enabled");
                 Service.Configuration.PluginEnabled = true;
+                Service.Configuration.Save();
                 break;
         }
     }


### PR DESCRIPTION
Fixed a bug where the plugin would stop working when a player adds a new minion to favourites: 

- Root cause fixed in SwapManager.cs file, where the update loop could be unsubscribed while internal tick state stayed non-zero, which blocked all future swap cycles until plugin reload.
- Refactored to explicit lifecycle methods (StartSwapCycle, StopSwapCycle, ResetTickState) with _isUpdateSubscribed guard so handler registration/unregistration is always consistent.
- Initialized _lastZone in Init() to current territory and removed the fragile _frameTick == 0 gate from zone-change scheduling.
- Updated command toggling in MinionRoulette.cs to persist config immediately (Service.Configuration.Save()), keeping runtime and saved state aligned.